### PR TITLE
fix(nx-biome): run biome from workspace root instead of cwd

### DIFF
--- a/packages/nx-biome/src/executors/biome/executor.batch.ts
+++ b/packages/nx-biome/src/executors/biome/executor.batch.ts
@@ -16,9 +16,10 @@ export default async function biomeBatchExecutor(
   taskGraph: TaskGraph,
   options: Record<string, BiomeExecutorOptions>,
   _overrides: BiomeExecutorOptions,
-  _context: ExecutorContext
+  context: ExecutorContext
 ): Promise<Record<string, BatchExecutorTaskResult>> {
   const tasks = Object.values(taskGraph.tasks)
+  const workspaceRoot = context.root
 
   // Get project roots from task options (keyed by task ID)
   const projectRoots = tasks.map((task) => {
@@ -38,7 +39,7 @@ export default async function biomeBatchExecutor(
     // Run biome check on all project directories at once
     const output = execSync(`biome check ${args}`, {
       stdio: "pipe",
-      cwd: process.cwd(),
+      cwd: workspaceRoot,
       encoding: "utf-8",
     })
     terminalOutput = output

--- a/packages/nx-biome/src/executors/biome/executor.spec.ts
+++ b/packages/nx-biome/src/executors/biome/executor.spec.ts
@@ -58,7 +58,7 @@ describe("nx-biome executor", () => {
 
     expect(childProcess.execSync).toHaveBeenCalledWith("biome check apps/proj", {
       stdio: "inherit",
-      cwd: process.cwd(),
+      cwd: context.root,
     })
     expect(result.success).toBe(true)
   })
@@ -70,7 +70,7 @@ describe("nx-biome executor", () => {
 
     expect(childProcess.execSync).toHaveBeenCalledWith("biome check .", {
       stdio: "inherit",
-      cwd: process.cwd(),
+      cwd: context.root,
     })
   })
 
@@ -134,7 +134,7 @@ describe("nx-biome batch executor", () => {
       "biome check apps/proj libs/lib",
       expect.objectContaining({
         stdio: "pipe",
-        cwd: process.cwd(),
+        cwd: context.root,
         encoding: "utf-8",
       })
     )
@@ -176,7 +176,7 @@ describe("nx-biome batch executor", () => {
       "biome check apps/proj",
       expect.objectContaining({
         stdio: "pipe",
-        cwd: process.cwd(),
+        cwd: context.root,
       })
     )
   })

--- a/packages/nx-biome/src/executors/biome/executor.ts
+++ b/packages/nx-biome/src/executors/biome/executor.ts
@@ -7,14 +7,15 @@ import type { BiomeExecutorOptions } from "./schema"
  */
 export default async function biomeExecutor(
   options: BiomeExecutorOptions,
-  _context: ExecutorContext
+  context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const projectRoot = options.projectRoot || "."
+  const workspaceRoot = context.root
 
   try {
     execSync(`biome check ${projectRoot}`, {
       stdio: "inherit",
-      cwd: process.cwd(),
+      cwd: workspaceRoot,
     })
     return { success: true }
   } catch {


### PR DESCRIPTION
When running nx commands from a subdirectory of the workspace, biome would fail because it was using process.cwd() instead of the workspace root. This fix ensures biome always runs from the workspace root using context.root from the ExecutorContext.

# Description

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #
