### PR TITLE
fix(nx-knip): pass env options from plugin config to executor

### DIFF
--- a/packages/nx-knip/src/plugins/plugin.ts
+++ b/packages/nx-knip/src/plugins/plugin.ts
@@ -8,6 +8,7 @@ const projectConfigGlob = "**/package.json"
 
 export interface KnipPluginOptions {
   targetName?: string
+  env?: Record<string, string>
 }
 
 export const createNodesV2: CreateNodesV2<KnipPluginOptions> = [
@@ -64,6 +65,7 @@ export const createNodesV2: CreateNodesV2<KnipPluginOptions> = [
                   options: {
                     projectRoot,
                     strict: true,
+                    ...(pluginOptions?.env && { env: pluginOptions.env }),
                   },
                   metadata: {
                     technologies: ["knip"],


### PR DESCRIPTION
## Summary

- Fix knip plugin inference to forward `env` options from plugin configuration to the executor, enabling environment variable customization for knip targets
- Rewrite AGENTS.md with comprehensive guidance covering all four plugins, build/test commands, code style guidelines, naming conventions, and testing patterns