### PR TITLE
fix(nx-knip): remove strict as default and support it as plugin option

### DIFF
--- a/packages/nx-knip/README.md
+++ b/packages/nx-knip/README.md
@@ -87,16 +87,36 @@ nx run-many -t knip
 
 ### `strict`
 
-Enable strict mode to also report unused dependencies and unlisted binaries. The plugin enables this by default for all inferred targets.
+Enable [strict mode](https://knip.dev/features/production-mode#strict-mode) (implies `--production`). Defaults to `false`. When enabled, knip will:
 
-You can override this per-project in `project.json`:
+- Verify isolation: workspaces should use strictly their own dependencies
+- Include `peerDependencies` when finding unused or unlisted dependencies
+- Report type-only imports listed in `dependencies`
+
+You can enable it for all projects via the plugin options in `nx.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "plugin": "@berenddeboer/nx-knip",
+      "options": {
+        "targetName": "knip",
+        "strict": true
+      }
+    }
+  ]
+}
+```
+
+Or per-project in `project.json`:
 
 ```json
 {
   "targets": {
     "knip": {
       "options": {
-        "strict": false
+        "strict": true
       }
     }
   }

--- a/packages/nx-knip/src/executors/knip/schema.json
+++ b/packages/nx-knip/src/executors/knip/schema.json
@@ -11,7 +11,7 @@
     },
     "strict": {
       "type": "boolean",
-      "description": "Enable strict mode to also report unused dependencies and unlisted binaries",
+      "description": "Enable strict mode (implies --production). Verifies workspace dependency isolation, includes peerDependencies when finding unused or unlisted dependencies, and reports type-only imports listed in dependencies.",
       "default": false
     },
     "env": {

--- a/packages/nx-knip/src/plugins/plugin.spec.ts
+++ b/packages/nx-knip/src/plugins/plugin.spec.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type { CreateNodesContext } from "@nx/devkit"
+import { createNodesV2 } from "./plugin"
+
+describe("@berenddeboer/nx-knip/plugin", () => {
+  const createNodesFunction = createNodesV2[1]
+  let context: CreateNodesContext
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "nx-knip-test"))
+    context = {
+      nxJsonConfiguration: {},
+      workspaceRoot: tempDir,
+      configFiles: [],
+    }
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function createPackageJson(projectRoot: string) {
+    const dir = join(tempDir, projectRoot)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: projectRoot }))
+  }
+
+  it("should infer knip target for a project", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(["packages/my-lib/package.json"], {}, context)
+    const project = nodes[0][1].projects["packages/my-lib"]
+
+    expect(project.targets).toHaveProperty("knip")
+    expect(project.targets.knip.executor).toBe("@berenddeboer/nx-knip:knip")
+  })
+
+  it("should use custom target name", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(
+      ["packages/my-lib/package.json"],
+      { targetName: "lint-unused" },
+      context
+    )
+    const project = nodes[0][1].projects["packages/my-lib"]
+
+    expect(project.targets).toHaveProperty("lint-unused")
+    expect(project.targets).not.toHaveProperty("knip")
+  })
+
+  it("should skip root package.json", async () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ name: "root" }))
+    const nodes = await createNodesFunction(["package.json"], {}, context)
+
+    expect(nodes[0][1]).toEqual({})
+  })
+
+  it("should skip node_modules", async () => {
+    const nodes = await createNodesFunction(
+      ["node_modules/some-pkg/package.json"],
+      {},
+      context
+    )
+
+    expect(nodes[0][1]).toEqual({})
+  })
+
+  it("should not include strict in options by default", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(["packages/my-lib/package.json"], {}, context)
+    const options = nodes[0][1].projects["packages/my-lib"].targets.knip.options
+
+    expect(options).not.toHaveProperty("strict")
+  })
+
+  it("should pass strict option when set to true", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(
+      ["packages/my-lib/package.json"],
+      { strict: true },
+      context
+    )
+    const options = nodes[0][1].projects["packages/my-lib"].targets.knip.options
+
+    expect(options.strict).toBe(true)
+  })
+
+  it("should pass strict option when set to false", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(
+      ["packages/my-lib/package.json"],
+      { strict: false },
+      context
+    )
+    const options = nodes[0][1].projects["packages/my-lib"].targets.knip.options
+
+    expect(options.strict).toBe(false)
+  })
+
+  it("should pass env option when provided", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(
+      ["packages/my-lib/package.json"],
+      { env: { DATABASE_URL: "postgres://localhost/dummy" } },
+      context
+    )
+    const options = nodes[0][1].projects["packages/my-lib"].targets.knip.options
+
+    expect(options.env).toEqual({ DATABASE_URL: "postgres://localhost/dummy" })
+  })
+})

--- a/packages/nx-knip/src/plugins/plugin.ts
+++ b/packages/nx-knip/src/plugins/plugin.ts
@@ -8,6 +8,7 @@ const projectConfigGlob = "**/package.json"
 
 export interface KnipPluginOptions {
   targetName?: string
+  strict?: boolean
   env?: Record<string, string>
 }
 
@@ -64,7 +65,9 @@ export const createNodesV2: CreateNodesV2<KnipPluginOptions> = [
                   executor: "@berenddeboer/nx-knip:knip",
                   options: {
                     projectRoot,
-                    strict: true,
+                    ...(pluginOptions?.strict != null && {
+                      strict: pluginOptions.strict,
+                    }),
                     ...(pluginOptions?.env && { env: pluginOptions.env }),
                   },
                   metadata: {


### PR DESCRIPTION
## Summary

- **Remove hardcoded `strict: true`** from plugin inference — strict mode was being forced on for all inferred targets, which doesn't work well for most projects
- **Add `strict` as a plugin option** in `KnipPluginOptions` so it can be configured in `nx.json` under the plugin's `options` (alongside `targetName` and `env`)
- **Fix the `strict` description** in both `schema.json` and `README.md` to match the [official knip docs](https://knip.dev/features/production-mode#strict-mode): strict implies `--production`, verifies workspace dependency isolation, includes peerDependencies, and reports type-only imports in dependencies
- **Add plugin inference tests** (`plugin.spec.ts`) covering target creation, custom target names, strict/env passthrough, and skip behavior for root/node_modules