### PR TITLE
fix(nx-biome): infer lint target for package.json-based projects

### DIFF
--- a/packages/nx-biome/src/plugins/plugin.spec.ts
+++ b/packages/nx-biome/src/plugins/plugin.spec.ts
@@ -1,0 +1,104 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type { CreateNodesContext } from "@nx/devkit"
+import { createNodesV2 } from "./plugin"
+
+describe("@berenddeboer/nx-biome/plugin", () => {
+  const createNodesFunction = createNodesV2[1]
+  let context: CreateNodesContext
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "nx-biome-test"))
+    context = {
+      nxJsonConfiguration: {},
+      workspaceRoot: tempDir,
+      configFiles: [],
+    }
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function createProjectJson(projectRoot: string) {
+    const dir = join(tempDir, projectRoot)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "project.json"), JSON.stringify({ name: projectRoot }))
+  }
+
+  function createPackageJson(projectRoot: string) {
+    const dir = join(tempDir, projectRoot)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: projectRoot }))
+  }
+
+  it("should infer lint target for a project.json-based project", async () => {
+    createProjectJson("packages/my-lib")
+    const nodes = await createNodesFunction(
+      ["packages/my-lib/project.json"],
+      {},
+      context
+    )
+    const project = nodes[0][1].projects["packages/my-lib"]
+
+    expect(project.targets).toHaveProperty("lint")
+    expect(project.targets.lint.executor).toBe("@berenddeboer/nx-biome:biome")
+  })
+
+  it("should infer lint target for a package.json-inferred project", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(
+      ["packages/my-lib/package.json"],
+      {},
+      context
+    )
+    const project = nodes[0][1].projects["packages/my-lib"]
+
+    expect(project.targets).toHaveProperty("lint")
+    expect(project.targets.lint.executor).toBe("@berenddeboer/nx-biome:biome")
+  })
+
+  it("should use custom target name for package.json-inferred project", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(
+      ["packages/my-lib/package.json"],
+      { targetName: "biome-lint" },
+      context
+    )
+    const project = nodes[0][1].projects["packages/my-lib"]
+
+    expect(project.targets).toHaveProperty("biome-lint")
+    expect(project.targets).not.toHaveProperty("lint")
+  })
+
+  it("should skip root package.json", async () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ name: "root" }))
+    const nodes = await createNodesFunction(["package.json"], {}, context)
+
+    expect(nodes[0][1]).toEqual({})
+  })
+
+  it("should skip node_modules", async () => {
+    const nodes = await createNodesFunction(
+      ["node_modules/some-pkg/package.json"],
+      {},
+      context
+    )
+
+    expect(nodes[0][1]).toEqual({})
+  })
+
+  it("should set projectRoot in executor options for package.json-inferred project", async () => {
+    createPackageJson("packages/my-lib")
+    const nodes = await createNodesFunction(
+      ["packages/my-lib/package.json"],
+      {},
+      context
+    )
+    const target = nodes[0][1].projects["packages/my-lib"].targets.lint
+
+    expect(target.options.projectRoot).toBe("packages/my-lib")
+  })
+})

--- a/packages/nx-biome/src/plugins/plugin.spec.ts
+++ b/packages/nx-biome/src/plugins/plugin.spec.ts
@@ -36,11 +36,7 @@ describe("@berenddeboer/nx-biome/plugin", () => {
 
   it("should infer lint target for a project.json-based project", async () => {
     createProjectJson("packages/my-lib")
-    const nodes = await createNodesFunction(
-      ["packages/my-lib/project.json"],
-      {},
-      context
-    )
+    const nodes = await createNodesFunction(["packages/my-lib/project.json"], {}, context)
     const project = nodes[0][1].projects["packages/my-lib"]
 
     expect(project.targets).toHaveProperty("lint")
@@ -49,11 +45,7 @@ describe("@berenddeboer/nx-biome/plugin", () => {
 
   it("should infer lint target for a package.json-inferred project", async () => {
     createPackageJson("packages/my-lib")
-    const nodes = await createNodesFunction(
-      ["packages/my-lib/package.json"],
-      {},
-      context
-    )
+    const nodes = await createNodesFunction(["packages/my-lib/package.json"], {}, context)
     const project = nodes[0][1].projects["packages/my-lib"]
 
     expect(project.targets).toHaveProperty("lint")
@@ -92,11 +84,7 @@ describe("@berenddeboer/nx-biome/plugin", () => {
 
   it("should set projectRoot in executor options for package.json-inferred project", async () => {
     createPackageJson("packages/my-lib")
-    const nodes = await createNodesFunction(
-      ["packages/my-lib/package.json"],
-      {},
-      context
-    )
+    const nodes = await createNodesFunction(["packages/my-lib/package.json"], {}, context)
     const target = nodes[0][1].projects["packages/my-lib"].targets.lint
 
     expect(target.options.projectRoot).toBe("packages/my-lib")

--- a/packages/nx-biome/src/plugins/plugin.ts
+++ b/packages/nx-biome/src/plugins/plugin.ts
@@ -1,9 +1,10 @@
+import { dirname } from "node:path"
 import { type CreateNodesV2, createNodesFromFiles } from "@nx/devkit"
 
 export const name = "nx-biome-plugin"
 
-// Match all project.json files to infer lint target for each project
-const projectConfigGlob = "**/project.json"
+// Match both project.json and package.json to infer lint target for each project
+const projectConfigGlob = "**/{project,package}.json"
 
 export interface BiomePluginOptions {
   targetName?: string
@@ -14,7 +15,23 @@ export const createNodesV2: CreateNodesV2<BiomePluginOptions> = [
   async (configFiles, options, context) => {
     return await createNodesFromFiles(
       (configFile, options, _context) => {
-        const projectRoot = configFile.replace("/project.json", "") || "."
+        // Skip node_modules
+        if (configFile.includes("node_modules")) {
+          return {}
+        }
+
+        let projectRoot: string
+        if (configFile.endsWith("/project.json")) {
+          projectRoot = configFile.replace("/project.json", "") || "."
+        } else {
+          // package.json
+          projectRoot = dirname(configFile)
+          // Skip root package.json
+          if (projectRoot === ".") {
+            return {}
+          }
+        }
+
         const targetName = options?.targetName ?? "lint"
 
         return {


### PR DESCRIPTION
Fixes #15

The plugin glob was changed from `**/project.json` to `**/{project,package}.json` so it now detects both `project.json` and `package.json`-based projects. Adds node_modules and root package.json skipping.

Generated with [Claude Code](https://claude.ai/code)